### PR TITLE
Dwest/dev

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -1,7 +1,7 @@
 # == Define: dhcp::host
 #
 define dhcp::host (
-  Optional $ip                          = undef,
+  Optional[Stdlib::Host] $ip            = undef,
   Dhcp::Mac $mac,
   String $ddns_hostname                 = $name,
   Hash $options                         = {},

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -1,7 +1,7 @@
 # == Define: dhcp::host
 #
 define dhcp::host (
-  Optional[Stdlib::IP::Address] $ip     = undef,
+  Optional $ip                          = undef,
   Dhcp::Mac $mac,
   String $ddns_hostname                 = $name,
   Hash $options                         = {},

--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -14,6 +14,7 @@ define dhcp::pool (
   Optional[Integer] $mtu                    = undef,
   String $domain_name                       = '',
   $ignore_unknown                           = undef,
+  Optional[Integer] $max_lease_time         = undef,
 ) {
   include dhcp::params
 

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -12,7 +12,7 @@ subnet <%= @network %> netmask <%= @mask %> {
 <% if @ignore_unknown == true -%>
     ignore unknown-clients ;
 <% end -%>
-<% if @max_lease_time != '' -%>
+<% if @max_lease_time -%>
     max-lease-time <%= @max_lease_time %>;
 <% end -%>
 <% if @range and @range.is_a? Array -%>

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -12,6 +12,9 @@ subnet <%= @network %> netmask <%= @mask %> {
 <% if @ignore_unknown == true -%>
     ignore unknown-clients ;
 <% end -%>
+<% if @max_lease_time != '' -%>
+    max-lease-time <%= @max_lease_time %>;
+<% end -%>
 <% if @range and @range.is_a? Array -%>
 <% @range.each do |r| -%>
     range <%= r %>;


### PR DESCRIPTION
#### Pull Request (PR) description
This changes the $ip validation so that you can use a valid `fqdn` value in addition to `ipv4` and `ipv6` to determine which IP should be allocated to a host. This uses DNS lookups based on the `fqdn` in the `fixed-address` field.  The result is that you can manage all of your IP allocation from DNS instead of having to duplicate the same information in DHCP.

I also added an optional parameter that allows you to specify the `max-lease-time` in the each DHCP pools scope, which will override the default value in `dhcpd.conf`.  This allows you to have different lease times for different pools.

#### This Pull Request (PR) fixes the following issues
Fixes #224
